### PR TITLE
refactor - don’t apply ElementContentDataExtension by default

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -4,19 +4,20 @@ Name: dynamicelementsconfig
 Dynamic\Elements\Elements\ElementCustomerService:
   extensions:
     - Dynamic\SilverStripeGeocoder\AddressDataExtension
+
 Dynamic\Elements\Elements\ElementSlideshow:
   extensions:
     - Dynamic\FlexSlider\ORM\FlexSlider
+
 Dynamic\FlexSlider\Model\SlideImage:
   extensions:
     - Dynamic\Elements\ORM\ElementSlideshowSlideDataExtension
+
 Sheadawson\Linkable\Models\Link:
   templates:
     button: 'Display link as a button'
     buttonghost: 'Display link as a ghost button'
-DNADesign\Elemental\Models\ElementContent:
-  extensions:
-    - Dynamic\Elements\ORM\ElementContentDataExtension
+
 SilverStripe\Admin\LeftAndMain:
   extensions:
     - Dynamic\Elements\Extensions\LeftAndMainExtension

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,13 @@
 {
     "name": "dynamic/silverstripe-elemental-blocks",
+    "type": "silverstripe-vendormodule",
     "description": "Additional elements for the SilverStripe Elemental module",
+    "keywords": [
+        "silverstripe",
+        "elemental",
+        "blocks"
+    ],
+    "license": "BSD-3-Clause",
     "authors": [
         {
             "name": "Dynamic",
@@ -8,43 +15,22 @@
             "homepage": "http://www.dynamicagency.com"
         }
     ],
-    "keywords": [
-        "silverstripe",
-        "elemental",
-        "blocks"
-    ],
-    "type": "silverstripe-vendormodule",
-    "license": "BSD-3-Clause",
-    "repositories": [
-        {
-            "type": "git",
-            "url": "https://github.com/SilverStripers/silverstripe-display-logic.git"
-        }
-    ],
     "require": {
-        "silverstripe/recipe-cms": "^1.0@dev",
-        "silverstripe/vendor-plugin": "^1.0@dev",
+        "dnadesign/silverstripe-elemental": "^2@dev",
         "dynamic/flexslider": "^3.0@dev",
         "dynamic/silverstripe-geocoder": "^1@dev",
-        "dnadesign/silverstripe-elemental": "^2@dev",
-        "unclecheese/display-logic": "dev-ss4-upgrade",
-        "sheadawson/silverstripe-linkable": "^2.0@dev"
+        "sheadawson/silverstripe-linkable": "^2.0@dev",
+        "silverstripe/recipe-cms": "^1.0@dev",
+        "silverstripe/vendor-plugin": "^1.0@dev",
+        "unclecheese/display-logic": "dev-ss4-upgrade"
     },
     "require-dev": {
         "phpunit/PHPUnit": "^5.7",
         "squizlabs/php_codesniffer": "*"
     },
-    "autoload": {
-        "psr-4": {
-            "Dynamic\\Elements\\": "src/",
-            "Dynamic\\Elements\\Tests\\": "tests/"
-        }
-    },
     "config": {
         "process-timeout": 600
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
     "extra": {
         "expose": [
             "thirdparty",
@@ -54,6 +40,20 @@
             "dev-master": "2.0.x-dev"
         }
     },
+    "autoload": {
+        "psr-4": {
+            "Dynamic\\Elements\\": "src/",
+            "Dynamic\\Elements\\Tests\\": "tests/"
+        }
+    },
+    "repositories": [
+        {
+            "type": "git",
+            "url": "https://github.com/SilverStripers/silverstripe-display-logic.git"
+        }
+    ],
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "scripts": {
         "lint": "vendor/bin/phpcs src/ tests/",
         "lint-clean": "vendor/bin/phpcbf src/ tests/"

--- a/tests/Extensions/ElementContentDataExtensionTest.php
+++ b/tests/Extensions/ElementContentDataExtensionTest.php
@@ -15,14 +15,21 @@ class ElementContentDataExtensionTest extends SapphireTest
     protected static $fixture_file = '../fixtures.yml';
 
     /**
+     * @var array
+     */
+    protected static $required_extensions = [
+        ElementContent::class => [
+            ElementContentDataExtension::class,
+        ],
+    ];
+
+    /**
      *
      */
     public function testGetCMSFields()
     {
         $object = $this->objFromFixture(ElementContent::class, 'default');
-        $ext = new ElementContentDataExtension();
         $fields = $object->getCMSFields();
-        $fields = $ext->updateCMSFields($fields);
         $this->assertInstanceOf(FieldList::class, $fields);
     }
 }

--- a/tests/Extensions/ElementContentDataExtensionTest.php
+++ b/tests/Extensions/ElementContentDataExtensionTest.php
@@ -3,6 +3,7 @@
 namespace Dynamic\Elements\Tests;
 
 use DNADesign\Elemental\Models\ElementContent;
+use Dynamic\Elements\ORM\ElementContentDataExtension;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Forms\FieldList;
 
@@ -19,7 +20,9 @@ class ElementContentDataExtensionTest extends SapphireTest
     public function testGetCMSFields()
     {
         $object = $this->objFromFixture(ElementContent::class, 'default');
+        $ext = new ElementContentDataExtension();
         $fields = $object->getCMSFields();
+        $fields = $ext->updateCMSFields($fields);
         $this->assertInstanceOf(FieldList::class, $fields);
     }
 }


### PR DESCRIPTION
normalize composer.json